### PR TITLE
Change height of container to 100%

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,8 @@ class GeoPlugin {
   async updateMap() {
     if (!this.container) {
       this.container = document.createElement('div');
-      this.container.style.height = '500px';
+      this.container.style.height = '100%';
+      this.container.style.minHeight = '500px';
       this.container.style.width = '100%';
       const map = L.map(this.container, {
         center: [50 + 38 / 60 + 28 / 3600, 4 + 40 / 60 + 5 / 3600],


### PR DESCRIPTION
I've been working on creating a nice layout for my [Yasgui fork](https://github.com/Matdata-eu/yasgui). I would like this plugin to always take up 100% of the parent element (and on my [yasgui website](https://yasgui.matdata.eu/), that would mean that it's taking up the entire page minus the code editor). The geo plugin now sets its height to 500px. This pull request changes that to 100% and sets the min-height to 500px.